### PR TITLE
43 add background worker

### DIFF
--- a/dotnet/TF2SA.StatsETLService/DependencyInjection.cs
+++ b/dotnet/TF2SA.StatsETLService/DependencyInjection.cs
@@ -1,3 +1,5 @@
+using TF2SA.Data;
+
 namespace TF2SA.StatsETLService
 {
     public static class DependencyInjection
@@ -6,6 +8,7 @@ namespace TF2SA.StatsETLService
             this IServiceCollection services,
             IConfiguration configuration)
         {
+            services.AddDataLayer(configuration);
             services.AddHostedService<StatsETLServiceRunner>();
             services.AddScoped<IStatsETLService, StatsETLService>();
         }

--- a/dotnet/TF2SA.StatsETLService/DependencyInjection.cs
+++ b/dotnet/TF2SA.StatsETLService/DependencyInjection.cs
@@ -1,0 +1,13 @@
+namespace TF2SA.StatsETLService
+{
+    public static class DependencyInjection
+    {
+        public static void AddStatsETLService(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            services.AddHostedService<StatsETLServiceRunner>();
+            services.AddScoped<IStatsETLService, StatsETLService>();
+        }
+    }
+}

--- a/dotnet/TF2SA.StatsETLService/IStatsETLService.cs
+++ b/dotnet/TF2SA.StatsETLService/IStatsETLService.cs
@@ -1,0 +1,7 @@
+namespace TF2SA.StatsETLService
+{
+    internal interface IStatsETLService
+    {
+        Task ProcessLogs(CancellationToken cancellationToken);
+    }
+}

--- a/dotnet/TF2SA.StatsETLService/Program.cs
+++ b/dotnet/TF2SA.StatsETLService/Program.cs
@@ -1,0 +1,10 @@
+using TF2SA.StatsETLService;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((builderContext, services) =>
+    {
+        services.AddStatsETLService(builderContext.Configuration);
+    })
+    .Build();
+
+await host.RunAsync();

--- a/dotnet/TF2SA.StatsETLService/Properties/launchSettings.json
+++ b/dotnet/TF2SA.StatsETLService/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+﻿{
+  "profiles": {
+    "TF2SA.StatsETLService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/dotnet/TF2SA.StatsETLService/StatsETLService.cs
+++ b/dotnet/TF2SA.StatsETLService/StatsETLService.cs
@@ -1,13 +1,20 @@
+using TF2SA.Data.Entities.MariaDb;
+using TF2SA.Data.Repositories.Base;
+
 namespace TF2SA.StatsETLService
 {
     internal class StatsETLService : IStatsETLService
     {
         private int count = 0;
         private readonly ILogger<StatsETLService> logger;
+        private readonly IPlayersRepository<Player, ulong> playerRepository;
 
-        public StatsETLService(ILogger<StatsETLService> logger)
+        public StatsETLService(
+            ILogger<StatsETLService> logger,
+            IPlayersRepository<Player, ulong> playerRepository)
         {
             this.logger = logger;
+            this.playerRepository = playerRepository;
         }
 
         public async Task ProcessLogs(CancellationToken cancellationToken)
@@ -15,8 +22,9 @@ namespace TF2SA.StatsETLService
             while (!cancellationToken.IsCancellationRequested)
             {
                 count++;
-                logger.LogInformation($"Scoped Service executing: {count}");
-                await Task.Delay(1000, cancellationToken);
+                var playerCount = playerRepository.GetAll().Count;
+                logger.LogInformation($"Scoped Service executing: {count}, found {playerCount} players!");
+                await Task.Delay(5000, cancellationToken);
             }
         }
     }

--- a/dotnet/TF2SA.StatsETLService/StatsETLService.cs
+++ b/dotnet/TF2SA.StatsETLService/StatsETLService.cs
@@ -1,0 +1,23 @@
+namespace TF2SA.StatsETLService
+{
+    internal class StatsETLService : IStatsETLService
+    {
+        private int count = 0;
+        private readonly ILogger<StatsETLService> logger;
+
+        public StatsETLService(ILogger<StatsETLService> logger)
+        {
+            this.logger = logger;
+        }
+
+        public async Task ProcessLogs(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                count++;
+                logger.LogInformation($"Scoped Service executing: {count}");
+                await Task.Delay(1000, cancellationToken);
+            }
+        }
+    }
+}

--- a/dotnet/TF2SA.StatsETLService/StatsETLServiceRunner.cs
+++ b/dotnet/TF2SA.StatsETLService/StatsETLServiceRunner.cs
@@ -1,0 +1,41 @@
+namespace TF2SA.StatsETLService;
+
+public class StatsETLServiceRunner : BackgroundService
+{
+    private readonly ILogger<StatsETLServiceRunner> logger;
+    public IServiceProvider serviceProvider { get; }
+
+    public StatsETLServiceRunner(
+        ILogger<StatsETLServiceRunner> logger,
+        IServiceProvider serviceProvider)
+    {
+        this.logger = logger;
+        this.serviceProvider = serviceProvider;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Hosted service running.");
+
+        await DoWork(stoppingToken);
+    }
+
+    private async Task DoWork(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Pulling scoped service.");
+
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var scopedStatsETLService =
+                scope.ServiceProvider.GetRequiredService<IStatsETLService>();
+
+            await scopedStatsETLService.ProcessLogs(cancellationToken);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Hosted service stopping.");
+        await base.StopAsync(cancellationToken);
+    }
+}

--- a/dotnet/TF2SA.StatsETLService/TF2SA.StatsETLService.csproj
+++ b/dotnet/TF2SA.StatsETLService/TF2SA.StatsETLService.csproj
@@ -14,4 +14,9 @@
   <ItemGroup>
     <ProjectReference Include="..\TF2SA.Data\TF2SA.Data.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.json" CopyToPublishDirectory="Never"/>
+    <Content Update="appsettings.Development.json" CopyToPublishDirectory="Never"/>
+  </ItemGroup>
 </Project>

--- a/dotnet/TF2SA.StatsETLService/TF2SA.StatsETLService.csproj
+++ b/dotnet/TF2SA.StatsETLService/TF2SA.StatsETLService.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-TF2SA.StatsETLService-7488C2D4-40EA-44FD-80B6-20880C27B464</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TF2SA.Data\TF2SA.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet/TF2SA.StatsETLService/appsettings.Development.json
+++ b/dotnet/TF2SA.StatsETLService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/dotnet/TF2SA.StatsETLService/appsettings.json
+++ b/dotnet/TF2SA.StatsETLService/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/dotnet/TF2SA.Web/Program.cs
+++ b/dotnet/TF2SA.Web/Program.cs
@@ -1,14 +1,13 @@
 using TF2SA.Data;
+using TF2SA.StatsETLService;
 using Microsoft.AspNetCore.HttpOverrides;
-using TF2SA.Data.Entities.MariaDb;
-using TF2SA.Data.Repositories.Base;
-using TF2SA.Data.Repositories.MariaDb;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 builder.Services.AddDataLayer(builder.Configuration);
+builder.Services.AddStatsETLService(builder.Configuration);
 
 var app = builder.Build();
 

--- a/dotnet/TF2SA.Web/TF2SA.Web.csproj
+++ b/dotnet/TF2SA.Web/TF2SA.Web.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TF2SA.Data\TF2SA.Data.csproj" />
+    <ProjectReference Include="..\TF2SA.StatsETLService\TF2SA.StatsETLService.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/dotnet/dotnet.sln
+++ b/dotnet/dotnet.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TF2SA.Web", "TF2SA.Web\TF2S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TF2SA.Data", "TF2SA.Data\TF2SA.Data.csproj", "{6D0BFFE9-A6A0-417D-9AA1-81C66637A306}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TF2SA.StatsETLService", "TF2SA.StatsETLService\TF2SA.StatsETLService.csproj", "{9B25D668-673C-490D-8FDA-E6AA476ED742}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{6D0BFFE9-A6A0-417D-9AA1-81C66637A306}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D0BFFE9-A6A0-417D-9AA1-81C66637A306}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D0BFFE9-A6A0-417D-9AA1-81C66637A306}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B25D668-673C-490D-8FDA-E6AA476ED742}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B25D668-673C-490D-8FDA-E6AA476ED742}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B25D668-673C-490D-8FDA-E6AA476ED742}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B25D668-673C-490D-8FDA-E6AA476ED742}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Adds a background worker service skeleton.

This service gets injected into the main web application at startup, *or* you can start it by itself individually as a console application.

It has access to the data layer for future data access needs for processing our logs